### PR TITLE
Migrate from Workbox v4 to v5

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const workboxPlugin = require('workbox-webpack-plugin')
 const defaultGenerateConfig = {
   exclude: [/\.map$/, /^(?:asset-)manifest.*\.js(?:on)?$/],
   navigateFallback: '/index.html',
-  navigateFallbackBlacklist: [
+  navigateFallbackDenylist: [
     new RegExp('^/__'),
     new RegExp('/[^/]+\.[^/]+$'),
   ],


### PR DESCRIPTION
Based on the upgrade guide for migrating from v4 of workbox I have fixed the braking change introduced by using v5.

https://developer.chrome.com/docs/workbox/migration/migrate-from-v4/