### PR TITLE
Migrate to atleast until v6 + fixes dependancies

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const workboxPlugin = require('workbox-webpack-plugin')
 const defaultGenerateConfig = {
   exclude: [/\.map$/, /^(?:asset-)manifest.*\.js(?:on)?$/],
   navigateFallback: '/index.html',
-  navigateFallbackBlacklist: [
+  navigateFallbackDenylist: [
     new RegExp('^/__'),
     new RegExp('/[^/]+\.[^/]+$'),
   ],

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "David Moodie",
   "license": "MIT",
   "peerDependencies": {
-    "workbox-webpack-plugin": "^3.0.0",
+    "workbox-webpack-plugin": "*",
     "react-app-rewired": "*"
   },
   "repository": {


### PR DESCRIPTION
Had to use this module because had problems generating serviceworker with other methods for react-app-rewire. Problem being self.__WB_MANIFEST 